### PR TITLE
exclude changelog from bower export

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
 	"ignore": [
 		"readme.md",
 		"composer.json",
-		"package.json"
+		"package.json",
+		"changelog.txt"
 	]
 }


### PR DESCRIPTION
This excludes the (rather big) changelog from the exported bower package.